### PR TITLE
ID2: Don't include cipher signs when signs are off

### DIFF
--- a/worlds/ittle_dew_2/region_rules.py
+++ b/worlds/ittle_dew_2/region_rules.py
@@ -218,6 +218,8 @@ def create_regions_with_rules(world: "ID2World") -> None:
                         continue
                     if destination_name in location_name_groups["Hint Signs"]:
                         continue
+                    if destination_name in location_name_groups["Cipher Signs"]:
+                        continue
                 else:
                     if not options.include_super_secrets:
                         if destination_name in location_name_groups["Cipher Signs"]:


### PR DESCRIPTION
## What is this fixing or adding?

When the "include secret signs" setting is off, Cipher Signs should be excluded along with the other kinds of signs.

## How was this tested?

I generated a game with the APworld and ensured that there were no locations on signs anymore.

Note: the settings when Super Secrets are disabled still appear incorrect, because it will include things like the Hint Sign in Nowhere, which I'd guess should be a Super Secret even though it's not a cipher sign. I'll leave it up to you how you want to sort out that case.